### PR TITLE
docs: 배치 및 정산 프로세스 

### DIFF
--- a/revenue-service/src/main/java/com/project/revenueservice/batch/AdDailyRevenueBatch.java
+++ b/revenue-service/src/main/java/com/project/revenueservice/batch/AdDailyRevenueBatch.java
@@ -59,7 +59,7 @@ public class AdDailyRevenueBatch {
                 .build();
     }
 
-    // tasklet
+    // globalPricingTaskletStep : 광고 조회수별 단가 금액표 db에서 조회하여 Step ExecutionContext에 저장
     @Bean
     public Step globalPricingTaskletStep() {
         return new StepBuilder("globalPricingTaskletStep", jobRepository)
@@ -85,7 +85,7 @@ public class AdDailyRevenueBatch {
         };
     }
 
-    // Ad daily revenue step
+    // adDailyRevenueStep : 동영상 별로 삽입된 광고 갯수(=조회수)를 기반으로 정산 금액 계산하여 저장
     @Bean
     public Step adDailyRevenueStep() throws ParseException {
 
@@ -111,7 +111,7 @@ public class AdDailyRevenueBatch {
                 LocalDate parsedDate = LocalDate.parse(currentDate.substring(0,10), formatter);
 
                 if(iterator == null) {
-                    List<AdCountBatchDto> ads = streamingClient.getAdCountByDate(parsedDate);
+                    List<AdCountBatchDto> ads = streamingClient.getAdCountByDate(parsedDate); // 스트리밍 서비스의 광고 목록에서 특정 날짜에 해당하는 데이터 조회
                     iterator = ads.iterator();
                 }
 
@@ -130,7 +130,7 @@ public class AdDailyRevenueBatch {
 
             @Override
             public AdDailyRevenue process(AdCountBatchDto item) throws Exception {
-                long totalAmount = calculateAmountForViews(priceList, item.getAdCount());
+                long totalAmount = calculateAmountForViews(priceList, item.getAdCount()); // 정산 금액 계산
 
                 return AdDailyRevenue.builder()
                         .videoId(item.getVideoId())
@@ -148,6 +148,7 @@ public class AdDailyRevenueBatch {
                 .build();
     }
 
+    // 정산 금액 계산
     public long calculateAmountForViews(List<GlobalPricing> priceList, long views) {
         long totalAmount = 0;
         long remainingViews = views;

--- a/revenue-service/src/main/java/com/project/revenueservice/batch/VideoDailyRevenueBatch.java
+++ b/revenue-service/src/main/java/com/project/revenueservice/batch/VideoDailyRevenueBatch.java
@@ -60,7 +60,7 @@ public class VideoDailyRevenueBatch {
                 .build();
     }
 
-    // tasklet
+    // globalPricingTaskletStep : 영상 조회수별 단가 금액표 db에서 조회하여 Step ExecutionContext에 저장
     @Bean
     public Step globalPricingTaskletStep() {
         return new StepBuilder("globalPricingTaskletStep", jobRepository)
@@ -86,7 +86,7 @@ public class VideoDailyRevenueBatch {
         };
     }
 
-    // Video daily revenue step
+    // dailyRevenueStep : 일별 영상 조회수 별 정산 금액 계산하여 저장
     @Bean
     public Step dailyRevenueStep() throws ParseException {
         log.info("dailyRevenueStep");
@@ -125,7 +125,7 @@ public class VideoDailyRevenueBatch {
 
             @Override
             public VideoDailyRevenue process(VideoDailyStats item) throws Exception {
-                long totalAmount = calculateAmountForViews(priceList, item.getDailyViews());
+                long totalAmount = calculateAmountForViews(priceList, item.getDailyViews()); // 정산 금액 계산
 
                 return VideoDailyRevenue.builder()
                         .videoId(item.getVideoId())
@@ -143,6 +143,7 @@ public class VideoDailyRevenueBatch {
                 .build();
     }
 
+    // 정산 금액 계산
     public long calculateAmountForViews(List<GlobalPricing> priceList, long views) {
         long totalAmount = 0;
         long remainingViews = views;

--- a/revenue-service/src/main/java/com/project/revenueservice/batch/VideoStatsJobFlow.java
+++ b/revenue-service/src/main/java/com/project/revenueservice/batch/VideoStatsJobFlow.java
@@ -21,6 +21,8 @@ public class VideoStatsJobFlow {
     private final Job videoDailyRevenueJob;
     private final Job adDailyRevenueJob;
 
+    // Flow에 맞는 배치 잡 순차적으로 진행
+    // 누적 N일차 -> 일별 통계 (-> 매주 일: 주별 통계 -> 매달 1일: 월별 통계)-> 영상 일별 정산 -> 광고 일별 정산
     @Bean
     public Job combinedJob() {
         return new JobBuilder("combinedJob", jobRepository)
@@ -34,6 +36,7 @@ public class VideoStatsJobFlow {
                 .build();
     }
 
+    // 누적 N일차 job flow
     @Bean
     public Flow cumulativeJobFlow(Job videoCumulativeJob) {
         return new FlowBuilder<Flow>("videoCumulativeJobFlow")
@@ -43,6 +46,7 @@ public class VideoStatsJobFlow {
                 .build();
     }
 
+    // 일별 통계 job flow
     @Bean
     public Flow dailyStatsJobFlow(Job videoDailyStatsJob) {
         return new FlowBuilder<Flow>("dailyStatsJobFlow")
@@ -52,6 +56,7 @@ public class VideoStatsJobFlow {
                 .build();
     }
 
+    // 영상 일별 정산 job flow
     @Bean
     public Flow revenueJobFlow(Job videoDailyRevenueJob) {
         return new FlowBuilder<Flow>("revenueJobFlow")
@@ -61,6 +66,7 @@ public class VideoStatsJobFlow {
                 .build();
     }
 
+    // 광고 일별 정산 job flow
     @Bean
     public Flow adRevenueJobFlow(Job adDailyRevenueJob) {
         return new FlowBuilder<Flow>("adRevenueJobFlow")

--- a/revenue-service/src/main/java/com/project/revenueservice/dto/VideoDto.java
+++ b/revenue-service/src/main/java/com/project/revenueservice/dto/VideoDto.java
@@ -8,16 +8,11 @@ import java.io.Serializable;
 @Getter
 public class VideoDto implements Serializable {
     private Long id;
-    private Long duration;
     private Long views;
-    private String videoUrl;
 
     @Builder
-    public VideoDto(Long id, Long duration, Long views, String videoUrl) {
+    public VideoDto(Long id, Long views) {
         this.id = id;
-        this.duration = duration;
         this.views = views;
-        this.videoUrl = videoUrl;
-
     }
 }

--- a/revenue-service/src/main/java/com/project/revenueservice/entity/VideoCumulativeStats.java
+++ b/revenue-service/src/main/java/com/project/revenueservice/entity/VideoCumulativeStats.java
@@ -19,9 +19,6 @@ public class VideoCumulativeStats {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name="video_id")
-//    private Video video;
     private Long videoId;
 
     private long cumulativeViews; // 누적 조회수 , 집계 데이터로써 관리하기 위해 별도로 사용

--- a/revenue-service/src/main/java/com/project/revenueservice/schedule/VideoCumulativeSchedule.java
+++ b/revenue-service/src/main/java/com/project/revenueservice/schedule/VideoCumulativeSchedule.java
@@ -27,8 +27,7 @@ public class VideoCumulativeSchedule {
 
     // 매일 저녁 23시 59분에 스케줄링 설정
     // @Scheduled(cron = "*/5 * * * * *", zone = "Asia/Seoul") // 테스트용
-//    @Scheduled(cron = "0 59 23 * * *", zone = "Asia/Seoul")
-    @Scheduled(cron = "0 10 10 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 59 23 * * *", zone = "Asia/Seoul")
     public void combinedJob() throws Exception {
 
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH-mm-ss");

--- a/streaming-service/src/main/java/com/project/streamingservice/dto/VideoDto.java
+++ b/streaming-service/src/main/java/com/project/streamingservice/dto/VideoDto.java
@@ -6,16 +6,11 @@ import lombok.Getter;
 @Getter
 public class VideoDto {
     private Long id;
-    private Long duration;
-    private Long views;
-    private String videoUrl;
+    private Long videoViews;
 
     @Builder
-    public VideoDto(Long id, Long duration, Long views, String videoUrl) {
+    public VideoDto(Long id, Long videoViews) {
         this.id = id;
-        this.duration = duration;
-        this.views = views;
-        this.videoUrl = videoUrl;
-
+        this.videoViews = videoViews;
     }
 }

--- a/streaming-service/src/main/java/com/project/streamingservice/repository/VideoRepository.java
+++ b/streaming-service/src/main/java/com/project/streamingservice/repository/VideoRepository.java
@@ -16,6 +16,6 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
     @Query("SELECT v FROM Video v WHERE v.id = :id")
     Video batchFindById(@Param("id") long id);
 
-    @Query("SELECT new com.project.streamingservice.dto.VideoDto(v.id, v.duration, v.videoViews, v.videoUrl) FROM Video v")
+    @Query("SELECT new com.project.streamingservice.dto.VideoDto(v.id, v.videoViews) FROM Video v")
     List<VideoDto> batchFindAll();
 }


### PR DESCRIPTION
1. VideoCumulativeSchedule
매일 저녁 23시 59분에 스케줄링 실행


2. VideoStatsJobFlow
Flow에 맞는 배치 잡을 순차적으로 진행
누적 N일차 -> 일별 통계 (-> 매주 일: 주별 통계 -> 매달 1일: 월별 통계)-> 영상 일별 정산 -> 광고 일별 정산


3. VideoCumulativeJob
- viewStep : 동영상 별로 동영상 조회수 집계할 누적 N일차 VideoCumulativeStats 객체 생성
- watchTimeStep : 재생 내역을 바탕으로 동영상 별 재생 시간을 집계할 누적 N일차 VideoCumulativeStats 객체 생성


4. videoDailyStatsJob
- videoViewsTaskletStep : 동영상 목록(동영상 ID, 조회수) 조회하여 Step ExecutionContext에 저장
- calculateDiffViewsStep : 누적 N일차 조회수 - 누적 N-1일차 조회수를 통해 일별 조회수 계산하여 업데이트
- videoWatchTimeTaskletStep : 재생내역에서 동영상 별로 재생 시간 합산(SUM, GROUP BY)한 후 조회하여 Step ExecutionContext에 저장
- calculateDiffWatchTimeStep : 누적 N일차 재생시간 - 누적 N-1일차 재생시간을 통해 일별 재생시간 계산하여 업데이트


5. videoDailyRevenueJob
- globalPricingTaskletStep : 영상 조회수별 단가 금액표 db에서 조회하여 Step ExecutionContext에 저장
- dailyRevenueStep : 일별 영상 조회수 별 정산 금액 계산하여 저장


6. adDailyRevenueJob
- globalPricingTaskletStep : 광고 조회수별 단가 금액표 db에서 조회하여 Step ExecutionContext에 저장
- adDailyRevenueStep : 동영상 별로 삽입된 광고 갯수(=조회수)를 기반으로 정산 금액 계산하여 저장